### PR TITLE
Wait for merge status to resolve.

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -64,6 +64,10 @@ class MergeRequest(gitlab.Resource):
         return self.info['state']
 
     @property
+    def merge_status(self):
+        return self.info['merge_status']
+
+    @property
     def rebase_in_progress(self):
         return self.info.get('rebase_in_progress', False)
 

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -77,6 +77,8 @@ class SingleMergeJob(MergeJob):
                 self.wait_for_ci_to_pass(merge_request, actual_sha)
                 time.sleep(2)
 
+            self.wait_for_merge_status_to_resolve(merge_request)
+
             self.ensure_mergeable_mr(merge_request)
 
             try:

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -50,6 +50,7 @@ class MockLab:  # pylint: disable=too-few-public-methods
             'assignees': [{'id': self.user_id}],
             'approved_by': [],
             'state': 'opened',
+            'merge_status': 'can_be_merged',
             'sha': self.commit_info['id'],
             'source_project_id': 1234,
             'target_project_id': 1234,


### PR DESCRIPTION
Since GitLab 12.8, the merge_status of a merge request updates asynchonously.
This commit waits for merge_status to become 'can_be_merged', just after checking
that the pipeline runs green.

See here for more details:

https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr